### PR TITLE
Remove && from peer dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save indigo-react
 Install peer dependencies
 
 ```
-npm install --save styled-components && @reach/menu-button
+npm install --save styled-components @reach/menu-button
 ```
 
 **React**


### PR DESCRIPTION
`&&` processes `@reach/menu-button` as a command to the shell. Installing multiple packages just requires listing them together.