### PR TITLE
Box, Center: position statically

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 
 # Changelog
+1.2.15 (2020-11-11)
+    * Removes position:relative from <Box>
+    * Removes flex:0 to row and col
+
 1.2.14 (2020-11-11)
     * Adds LargeBullet for notification badge
     * Adds flex:0 to row and col for cross-browser compatibility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlon/indigo-react",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "React implementation of Tlon's design system, Indigo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -5,9 +5,6 @@ import { allSystemStyle, AllSystemProps } from "../systemHelpers";
 export type BoxProps = AllSystemProps;
 
 export const Box = styled.div<React.PropsWithChildren<BoxProps>>(
-  {
-    position: "relative",
-  },
   compose(...allSystemStyle)
 );
 

--- a/src/Center/Center.tsx
+++ b/src/Center/Center.tsx
@@ -5,7 +5,6 @@ export type CenterProps = StructureProps;
 
 export const Center = styled.div<React.PropsWithChildren<StructureProps>>(
   {
-    position: "relative",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",

--- a/src/Col/Col.tsx
+++ b/src/Col/Col.tsx
@@ -8,15 +8,11 @@ export type ColProps = AllSystemProps & {
   gapY?: ResponsiveValue<ThemeValue<"space", RequiredTheme>>;
 };
 
-// Some browsers do not honour minimum height for nested flex children
-// so we disable flexShrink by default
-const flexChild = { flexShrink: 0 };
-
 const style = ({ gapY }: ColProps) =>
   css({
     display: "flex",
     flexDirection: "column",
-    "& > *": typeof gapY === "undefined" ? flexChild : { ...flexChild, marginTop: gapY },
+    "& > *": typeof gapY === "undefined" ? {} : { marginTop: gapY },
     "& > :first-child": typeof gapY === "undefined" ? {} : { marginTop: 0 },
   } as SystemStyleObject);
 

--- a/src/Row/Row.tsx
+++ b/src/Row/Row.tsx
@@ -8,14 +8,10 @@ export type RowProps = AllSystemProps & {
   gapX?: ResponsiveValue<ThemeValue<"space", RequiredTheme>>;
 };
 
-// Some browsers do not honour minimum height for nested flex children
-// so we disable flexShrink by default
-const flexChild = { flexShrink: 0 };
-
 const style = ({ gapX }: RowProps) =>
   css({
     display: "flex",
-    "& > *": typeof gapX === "undefined" ? flexChild : { ...flexChild, marginRight: gapX },
+    "& > *": typeof gapX === "undefined" ? {} : { marginRight: gapX },
     "& > :last-child": typeof gapX === "undefined" ? {} : { marginRight: 0 },
   } as SystemStyleObject);
 


### PR DESCRIPTION
Positions Box and Center statically, so as to avoid the `flex-shrink` shenanigans. Also reverts the `flex-shrink: 0` change as the problems with `flex-shrink` disappear. 