### PR TITLE
quality of life fixes

### DIFF
--- a/src/Action.tsx
+++ b/src/Action.tsx
@@ -33,6 +33,7 @@ const style = ({
     border: "none",
     overflow: "hidden",
     height: 3,
+    backgroundColor: "white",
     ...action.text,
     ...stateColor(destructive, disabled, hideDisabled),
   } as SystemStyleObject);

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -44,6 +44,7 @@ const style = ({
     borderRadius: 2,
     overflow: "hidden",
     px: 3,
+    backgroundColor: "white",
     ...button.text,
     ...container.center,
     ...stateStyle(primary, destructive, disabled, hideDisabled),

--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -28,12 +28,7 @@ export const Icon = ({
   icon,
   ...props
 }: IconProps & { icon: keyof IconIndex }) => {
-  const InnerIcon = iconIndex[icon];
-
-  if (typeof InnerIcon === "undefined")
-    throw Error(
-      `Prop 'icon' on <Icon/> has value ${icon}. Key must exist in the Indigo React iconIndex`
-    );
+  const InnerIcon = iconIndex[icon] ?? iconIndex.NullIcon;
 
   return (
     <SVG color="black" {...props} viewBox={"0 0 16 16"}>


### PR DESCRIPTION
Icon: do not crash on invalid icon

Action, Button: default to white background

User agent stylesheets typically default to having a white background
for <button> elements, however these stylesheets are not using the
indigo white, which causes issues in dark mode
