### PR TITLE
lists: add ol, ul, and li support

### DIFF
--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -54,6 +54,9 @@ import {
   H2,
   H3,
   H4,
+  Li,
+  Ol,
+  Ul
 } from "local-indigo-react";
 import css, { SystemStyleObject } from "@styled-system/css";
 import { ThemeProvider } from "styled-components";
@@ -307,7 +310,26 @@ const App = () => {
             </Box>
           </Col>
         </TwoUp>
-
+        <Row>
+          <Col p={p} width="50%">
+            <Rule />
+            <Text py="2">{"<Ol />"}</Text>
+            <Ol>
+              <Li><Text>First</Text></Li>
+              <Li><Text>Second</Text></Li>
+              <Li><Text>Third</Text></Li>
+            </Ol>
+          </Col>
+           <Col p={p} width="50%">
+            <Rule />
+            <Text py="2">{"<Ul />"}</Text>
+            <Ul>
+              <Li><Text>Foo</Text></Li>
+              <Li><Text>Bar</Text></Li>
+              <Li><Text>Baz</Text></Li>
+            </Ul>
+          </Col>
+        </Row>
         <Row>
           <Col p={p} width="50%">
             <Rule />

--- a/src/Li.tsx
+++ b/src/Li.tsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+import { compose } from "styled-system";
+import { allSystemStyle, AllSystemProps } from "./system/unions";
+
+export type LiProps = AllSystemProps;
+
+export const Li = styled.li<React.PropsWithChildren<LiProps>>(
+  compose(...allSystemStyle)
+);
+
+Li.displayName = "Li";

--- a/src/Ol.tsx
+++ b/src/Ol.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { compose } from "styled-system";
+import { listStyle, ListProps } from "./system/unions";
+
+export type OlProps = ListProps;
+
+export const Ol = styled.ol<React.PropsWithChildren<OlProps>>(
+  compose(...listStyle)
+);
+
+Ol.defaultProps = {
+  listStyle: 'decimal'
+}
+
+Ol.displayName = "Ol";

--- a/src/Ul.tsx
+++ b/src/Ul.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { compose } from "styled-system";
+import { listStyle, ListProps } from "./system/unions";
+
+export type UlProps = ListProps;
+
+export const Ul = styled.ul<React.PropsWithChildren<UlProps>>(
+  compose(...listStyle)
+);
+
+Ul.defaultProps = {
+  listStyle: 'disc'
+}
+
+Ul.displayName = "Ul";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,9 @@ export { Badge } from "./Badge";
 /**
  * Layout
  */
+export { Ol, OlProps } from "./Ol";
+export { Ul, UlProps } from "./Ul";
+export { Li, LiProps } from "./Li";
 export { Row, RowProps } from "./Row";
 export { Col, ColProps } from "./Col";
 export { Paragraph, ParagraphProps } from "./Paragraph";

--- a/src/system/unions.ts
+++ b/src/system/unions.ts
@@ -147,3 +147,8 @@ export const typographicStyle = [
     textTransform: true,
   }),
 ];
+
+export const listStyle = [...allSystemStyle, system({ listStyle: true })];
+export type ListProps = AllSystemProps & {
+  listStyle?: string;
+}


### PR DESCRIPTION
Necessary to correctly render markdown on landscape without resorting to horrific hacks
![Screen Shot 2021-05-07 at 12 44 46 pm](https://user-images.githubusercontent.com/46801558/117391136-aff18a00-af32-11eb-84f9-f53f6799a7bf.png)
