### PR TITLE
add icon: pause icon

### DIFF
--- a/src/iconIndex.tsx
+++ b/src/iconIndex.tsx
@@ -836,6 +836,16 @@ const Bug = () => (
   </>
 );
 
+const Pause = () => (
+  <>
+    <path 
+      fillRule="evenodd" 
+      clipRule="evenodd" 
+      d="M2 0H0V8H2V0ZM6 0H4V8H6V0Z"
+    />
+  </>
+);
+
 export const iconIndex = {
   Visible,
   Hidden,
@@ -920,4 +930,5 @@ export const iconIndex = {
   NullIcon,
   Bug,
   Delete,
+  Pause,
 };


### PR DESCRIPTION
We'll be needing this for Collections mkII — it's based off the existing geometry of the play + next track + prev track icons!

<img width="617" alt="Screen Shot 2021-05-26 at 1 29 36 AM" src="https://user-images.githubusercontent.com/1195363/119607188-d8e29d80-bdc1-11eb-8926-4835cfef1295.png">

Let me know if i got the formatting of the svg correct, i just copied the svg information from the element within the 16px frame we use for icons:

<img width="153" alt="Screen Shot 2021-05-26 at 1 28 50 AM" src="https://user-images.githubusercontent.com/1195363/119607099-bc466580-bdc1-11eb-9e6e-2acd35a7be35.png">
